### PR TITLE
Autodeploy NCML under 1-Datasets/* folder to /data/ncml

### DIFF
--- a/deployment/deploy-pavics-vdb-ncml
+++ b/deployment/deploy-pavics-vdb-ncml
@@ -35,6 +35,7 @@ exec >>$LOG_FILE 2>&1
 
 cleanup_on_exit() {
     rm -rf "$TMPDIR"
+    set +x
     echo "
 $DESCRIPTION finished START_TIME=$START_TIME
 $DESCRIPTION finished   END_TIME=`date -Isecond`"


### PR DESCRIPTION
Standalone audeploy, independent from the PAVICS autodeploy, so we can choose the frequency we want (right now it's hourly) and we can execute custom script after clone if need be (for dynamic NCML generation later).

Note the autodeploy is for all the NCML files, not the autodeploy itself.  Changes to the autodeploy script will have to be deployed manually.

More docs in script header.

Done with the new "Datasets" top-level, see https://github.com/bird-house/birdhouse-deploy/pull/33.

Dev server: http://lvupavics-lvu.pagekite.me/twitcher/ows/proxy/thredds/catalog/datasets/catalog.html (only gridded_obs/nrcan.ncml works on my dev server).

The new autodeploy script is deployed to Medus but not the Thredds config change because it's not merged to master yet. You guys will have to use my dev server.