### PR TITLE
* GEPS forecast ncml pointing to symlink of latest netcdf

### DIFF
--- a/1-Datasets/forecasts/eccc_geps/GEPS_latest.ncml
+++ b/1-Datasets/forecasts/eccc_geps/GEPS_latest.ncml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" location="/pavics-data/eccc/forecasts/geps/GEPS_latest.nc"></netcdf>


### PR DESCRIPTION
Adds a single ncml to a new folder(s) in Datasets.  The ncml points to a statically named symlink linking to the latest geps forecast.
This allows us to not have to redeploy the ncml everytime the cron job is run