### PR TITLE
Delete thredds geps data older than 21 days

### DIFF
--- a/ECCC-datamart_sync/convert_grib2_to_nc.py
+++ b/ECCC-datamart_sync/convert_grib2_to_nc.py
@@ -89,7 +89,7 @@ def main():
             if jobs[j]['outpath'].joinpath(d.name.replace('.grib2', '.nc')).exists():
                 os.remove(jobs[j]['outpath'].joinpath(d.name.replace('.grib2', '.nc')).as_posix())
             # delete grib2 file
-            print(f"delete {d} and corresponding .nc since older than {keep_days} days")
+            print(f"delete '{d}' and corresponding .nc since older than '{keep_days}'")
             os.remove(d)
 
         # only convert grib2 files that have not already been converted
@@ -166,7 +166,7 @@ def main():
             else:
                 deletefiles.append(i)
         for d in deletefiles:
-            print(f"delete {d} since older than {keep_days} days")
+            print(f"delete '{d}' since older than '{keep_days}'")
             os.remove(d)
 
 def validate_ncml(url, start_date):


### PR DESCRIPTION
Currently the geps conversion only cleans up the tmp data folder and the final merged netcdfs on thredds server are not ever deleted in the same manner. 

Also added a small fix for dynamic naming of the 'current' symlink 