### PR TITLE
convert_grib2_to_nc.conf: fix output path only works on Boreas, not Notos

### DIFF
--- a/ECCC-datamart_sync/convert_grib2_to_nc.conf
+++ b/ECCC-datamart_sync/convert_grib2_to_nc.conf
@@ -27,7 +27,7 @@ LAUNCH_CONTAINER_ENV_VAR_PATH_LIST=" \
 # Same name as in LAUNCH_CONTAINER_ENV_VAR_PATH_LIST with "_DEFAULT" appended.
 CONVERT_GRIB2_TO_NC_INPATH_DEFAULT="/data/tmp/geps_forecast/grib2"
 CONVERT_GRIB2_TO_NC_OUTPATH_DEFAULT="/data/tmp/geps_forecast/netcdf"
-CONVERT_GRIB2_TO_NC_THREDDSPATH_DEFAULT="/pvcs1/DATA/eccc/forecasts/geps"
+CONVERT_GRIB2_TO_NC_THREDDSPATH_DEFAULT="/data/datasets/eccc/forecasts/geps"
 
 
 #


### PR DESCRIPTION
Seen this error when cronjob runs on Notos:

```
Traceback (most recent call last):
  File "ECCC-datamart_sync/convert_grib2_to_nc.py", line 296, in write_nc
    ds.load().to_netcdf(outfile, mode=mode, encoding=encoding, format='NETCDF4')
  File "/opt/conda/envs/birdy/lib/python3.8/site-packages/xarray/core/dataset.py", line 1644, in to_netcdf
    return to_netcdf(
  File "/opt/conda/envs/birdy/lib/python3.8/site-packages/xarray/backends/api.py", line 1094, in to_netcdf
    store = store_open(target, mode, format, group, **kwargs)
  File "/opt/conda/envs/birdy/lib/python3.8/site-packages/xarray/backends/netCDF4_.py", line 364, in open
    return cls(manager, group=group, mode=mode, lock=lock, autoclose=autoclose)
  File "/opt/conda/envs/birdy/lib/python3.8/site-packages/xarray/backends/netCDF4_.py", line 314, in __init__
    self.format = self.ds.data_model
  File "/opt/conda/envs/birdy/lib/python3.8/site-packages/xarray/backends/netCDF4_.py", line 373, in ds
    return self._acquire()
  File "/opt/conda/envs/birdy/lib/python3.8/site-packages/xarray/backends/netCDF4_.py", line 367, in _acquire
    with self._manager.acquire_context(needs_lock) as root:
  File "/opt/conda/envs/birdy/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/opt/conda/envs/birdy/lib/python3.8/site-packages/xarray/backends/file_manager.py", line 187, in acquire_context
    file, cached = self._acquire_with_cache_info(needs_lock)
  File "/opt/conda/envs/birdy/lib/python3.8/site-packages/xarray/backends/file_manager.py", line 205, in _acquire_with_cache_info
    file = self._opener(*self._args, **kwargs)
  File "netCDF4/_netCDF4.pyx", line 2357, in netCDF4._netCDF4.Dataset.__init__
  File "netCDF4/_netCDF4.pyx", line 1925, in netCDF4._netCDF4._ensure_nc_success
PermissionError: [Errno 13] Permission denied: b'/pvcs1/DATA/eccc/forecasts/geps/CMC_geps-raw_latlon0p5x0p5_2022033100_allP_allmbrs.nc'
```